### PR TITLE
Removed timeouts of some processes

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -62,7 +62,7 @@ class InstallCommand extends PackageCommand
         $io->writeln("Repository url: <file>{$package->getRepositoryUrl()}</file>");
 
         $process = new Process(['git', 'clone', $package->getRepositoryUrl(), $package->getPath()]);
-        $process->run();
+        $process->setTimeout(null)->run();
 
         if ($process->isSuccessful()) {
             $io->write($process->getOutput() . $process->getErrorOutput());
@@ -133,7 +133,7 @@ class InstallCommand extends PackageCommand
             $io->hasColorSupport() ? '--ansi' : '--no-ansi',
         ]);
 
-        $process->run();
+        $process->setTimeout(null)->run();
 
         if ($process->isSuccessful()) {
             $io->write($process->getOutput() . $process->getErrorOutput());

--- a/src/Command/PullCommand.php
+++ b/src/Command/PullCommand.php
@@ -50,7 +50,7 @@ class PullCommand extends PackageCommand
         $io->header($header);
 
         $process = new Process(['git', 'pull'], $package->getPath());
-        $process->run();
+        $process->setTimeout(null)->run();
 
         if ($process->isSuccessful()) {
             $io->write($process->getOutput() . $process->getErrorOutput());

--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -50,7 +50,7 @@ class PushCommand extends PackageCommand
         $io->header($header);
 
         $process = new Process(['git', 'push'], $package->getPath());
-        $process->run();
+        $process->setTimeout(null)->run();
 
         if ($process->isSuccessful()) {
             $io->write($process->getOutput() . $process->getErrorOutput());


### PR DESCRIPTION
The duration of operations, which depend on the network speed, is undefined, so we should not limit them to a timeout (Symfony Process component use 60 seconds timeout by default).