### PR TITLE
Add forgotten /debug file

### DIFF
--- a/debug
+++ b/debug
@@ -1,0 +1,2 @@
+#!/bin/sh
+env PHP_IDE_CONFIG="serverName=console" XDEBUG_CONFIG="idekey=PHPSTORM" $@


### PR DESCRIPTION
See related [Vagrant README section](https://github.com/yiisoft/yii-dev-tool/tree/master/vagrant#php-cli-debugging-using-xdebug-and-phpstorm) for details.