### PR TITLE
Issue #80: Improve command fix-dependencies

### DIFF
--- a/src/Command/FixDependenciesCommand.php
+++ b/src/Command/FixDependenciesCommand.php
@@ -27,7 +27,7 @@ class FixDependenciesCommand extends PackageCommand
 
     protected function getMessageWhenNothingHasBeenOutput(): ?string
     {
-        return '<success>✔ Nothing to fix</success>';
+        return '<success>✔ Done</success>';
     }
 
     protected function processPackage(Package $package): void

--- a/src/Component/CodeUsage/CodeUsage.php
+++ b/src/Component/CodeUsage/CodeUsage.php
@@ -19,7 +19,7 @@ class CodeUsage
      * @param string $identifier Unique identifier of code usage: namespace, package name, etc.
      * @param string[] $environments Environment in which the code is used.
      */
-    public function __construct(string $identifier, array $environments)
+    public function __construct(string $identifier, array $environments = [])
     {
         foreach ($environments as $environment) {
             if (!is_string($environment)) {

--- a/src/Component/CodeUsage/NamespaceUsageFinder.php
+++ b/src/Component/CodeUsage/NamespaceUsageFinder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Yiisoft\YiiDevTool\Component\CodeUsage;
 
 use InvalidArgumentException;

--- a/src/Component/Composer/ComposerConfig.php
+++ b/src/Component/Composer/ComposerConfig.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 class ComposerConfig
 {
+    public const SECTION_PROVIDE = 'provide';
     public const SECTION_REQUIRE = 'require';
     public const SECTION_REQUIRE_DEV = 'require-dev';
 
@@ -138,6 +139,11 @@ class ComposerConfig
         return $namespaces;
     }
 
+    public function sortPackagesEnabled(): bool
+    {
+        return isset($this->data['config']['sort-packages']) && $this->data['config']['sort-packages'] === true;
+    }
+
     public function hasSection(string $section): bool
     {
         return array_key_exists($section, $this->data);
@@ -151,6 +157,13 @@ class ComposerConfig
     public function setSection(string $section, $data): void
     {
         $this->data[$section] = $data;
+    }
+
+    public function removeSection($section): void
+    {
+        if ($this->hasSection($section)) {
+            unset($this->data[$section]);
+        }
     }
 
     private function internalMerge(array $a, array $b): array

--- a/src/Component/Composer/ComposerInstallation.php
+++ b/src/Component/Composer/ComposerInstallation.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\YiiDevTool\Component\Composer;
+
+class ComposerInstallation
+{
+    private ComposerPackage $rootPackage;
+    private array $installedDependencies;
+    private array $notInstalledDependencies;
+
+    public function __construct(ComposerPackage $rootPackage)
+    {
+        $this->rootPackage = $rootPackage;
+        $this->analyzeDependencies();
+    }
+
+    public function hasNotInstalledDependencies(): bool
+    {
+        return count($this->notInstalledDependencies) > 0;
+    }
+
+    /**
+     * @return ComposerPackage[]
+     */
+    public function getNotInstalledDependencies(): array
+    {
+        return $this->notInstalledDependencies;
+    }
+
+    /**
+     * @return ComposerPackage[]
+     */
+    public function getNonVirtualInstalledDependencies(): array
+    {
+        return $this->installedDependencies;
+    }
+
+    private function analyzeDependencies(): void
+    {
+        $dependencies = $this->rootPackage->getDependencyPackages();
+
+        $installed = [];
+        $notInstalled = [];
+
+        foreach ($dependencies as $dependency) {
+            if ($dependency->composerConfigFileExists()) {
+                $installed[] = $dependency;
+            } else {
+                $notInstalled[] = $dependency;
+            }
+        }
+
+        // Filter virtual packages provided by installed packages
+        foreach ($notInstalled as $notInstalledIndex => $notInstalledPackage) {
+            foreach ($installed as $installedPackage) {
+                if ($installedPackage->doesProvidePackage($notInstalledPackage->getName())) {
+                    unset($notInstalled[$notInstalledIndex]);
+                    break;
+                }
+            }
+        }
+
+        $this->installedDependencies = $installed;
+        $this->notInstalledDependencies = $notInstalled;
+    }
+}


### PR DESCRIPTION
1) Checks packages of all vendors, not just “yiisoft” vendor.
2) Takes into account packages that should be provided by other packages.
3) Keeps a version of packages unchanged when moving between sections “require” and “require-dev”.
4) Sorts dependencies if flag ‘sort-packages’ is set in composer config and dependency list has been changed.