### PR TITLE
Fix slashes in a proposed commands

### DIFF
--- a/src/Command/Replicate/ReplicateFilesCommand.php
+++ b/src/Command/Replicate/ReplicateFilesCommand.php
@@ -57,12 +57,13 @@ class ReplicateFilesCommand extends PackageCommand
 
         $replicationSourcePackage = $packageList->getPackage($replicationSourcePackageId);
         if (!$replicationSourcePackage->isGitRepositoryCloned()) {
+            $ds = DIRECTORY_SEPARATOR;
             $io->error([
                 "Package <package>$replicationSourcePackageId</package> is configured as replication source.",
                 'But such a package is not installed.',
                 'To fix, run the following command:',
                 '',
-                "  <cmd>./yii-dev install $replicationSourcePackageId</cmd>",
+                "  <cmd>.{$ds}yii-dev install $replicationSourcePackageId</cmd>",
                 '',
                 'Replication aborted.',
             ]);

--- a/src/Component/Console/PackageCommand.php
+++ b/src/Component/Console/PackageCommand.php
@@ -154,6 +154,7 @@ DESCRIPTION
     private function isCurrentInstallationValid(Package $package): bool
     {
         $io = $this->getIO();
+        $ds = DIRECTORY_SEPARATOR;
 
         if (!$package->isGitRepositoryCloned()) {
             // TODO: Implement extensible validation instead of checking command names
@@ -165,7 +166,7 @@ DESCRIPTION
                 "Package <package>{$package->getId()}</package> repository is not cloned.",
                 'To fix, run the command:',
                 '',
-                "  <cmd>./yii-dev install {$package->getId()}</cmd>",
+                "  <cmd>.{$ds}yii-dev install {$package->getId()}</cmd>",
             ]);
 
             if (!$this->areTargetPackagesSpecifiedExplicitly()) {
@@ -185,7 +186,7 @@ DESCRIPTION
                 "Package <package>{$package->getId()}</package> repository is cloned from <file>{$remoteOriginUrl}</file>, but url <file>{$package->getConfiguredRepositoryUrl()}</file> is configured.",
                 'To fix, delete the existing working copy of the repository and run the command:',
                 '',
-                "  <cmd>./yii-dev install {$package->getId()}</cmd>",
+                "  <cmd>.{$ds}yii-dev install {$package->getId()}</cmd>",
                 '',
                 'Before deleting, make sure that you do not have local changes, branches and tags that are not sent to remote repository.',
                 'You can also reconfigure the package repository url in <file>packages.local.php</file>',
@@ -203,7 +204,7 @@ DESCRIPTION
                         "Package <package>{$package->getId()}</package> repository is personal and has no remote 'upstream'.",
                         'To fix, run the command:',
                         '',
-                        "  <cmd>./yii-dev install {$package->getId()}</cmd>",
+                        "  <cmd>.{$ds}yii-dev install {$package->getId()}</cmd>",
                     ]);
 
                     return false;


### PR DESCRIPTION
Proposed commands like this is incompotable with windows cmd.

![image](https://user-images.githubusercontent.com/4152481/86494637-a3365f80-bd7e-11ea-86af-3663ca441f31.png)

This is inconvenient: when copying a command to the command line, you have to manually change the slash to a backslash.

In this PR i suggest replacing the static delimiter (`/`) with a `DIRECTORY_SEPARATOR` constant.

![image](https://user-images.githubusercontent.com/4152481/86494579-65d1d200-bd7e-11ea-8ae3-01148d0d90ea.png)

