### PR TITLE
Add --no-plugins option to install/update commands

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -2,7 +2,8 @@
 
 namespace Yiisoft\YiiDevTool\Command;
 
-use GitWrapper\Exception\GitException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -13,6 +14,7 @@ use Yiisoft\YiiDevTool\Component\Package\Package;
 class InstallCommand extends PackageCommand
 {
     private bool $updateMode = false;
+    private array $additionalComposerInstallOptions = [];
 
     public function useUpdateMode(): self
     {
@@ -25,9 +27,22 @@ class InstallCommand extends PackageCommand
     {
         $this
             ->setName('install')
-            ->setDescription('Install packages');
+            ->setDescription('Install packages')
+            ->addOption(
+                'no-plugins',
+                null,
+                InputOption::VALUE_NONE,
+                'Use <fg=green>--no-plugins</> during <fg=green;options=bold>composer install</>'
+            );
 
         $this->addPackageArgument();
+    }
+
+    protected function beforeProcessingPackages(InputInterface $input): void
+    {
+        if ($input->getOption('no-plugins') !== false) {
+            $this->additionalComposerInstallOptions[] = '--no-plugins';
+        }
     }
 
     protected function afterProcessingPackages(): void
@@ -135,6 +150,7 @@ class InstallCommand extends PackageCommand
             $composerCommandName,
             '--prefer-dist',
             '--no-progress',
+            ...$this->additionalComposerInstallOptions,
             '--working-dir',
             $package->getPath(),
             $io->hasColorSupport() ? '--ansi' : '--no-ansi',

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -4,6 +4,7 @@ namespace Yiisoft\YiiDevTool\Command;
 
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Yiisoft\YiiDevTool\Component\Console\PackageCommand;
 
@@ -13,7 +14,14 @@ class UpdateCommand extends PackageCommand
     {
         $this
             ->setName('update')
-            ->setDescription('Update packages');
+            ->setDescription('Update packages')
+            ->addOption(
+                'no-plugins',
+                null,
+                InputOption::VALUE_NONE,
+                'Use <fg=green>--no-plugins</> during <fg=green;options=bold>composer update</>'
+            );
+
 
         $this->addPackageArgument();
     }
@@ -26,6 +34,7 @@ class UpdateCommand extends PackageCommand
         /** @noinspection PhpUnhandledExceptionInspection */
         $installCommand->run(new ArrayInput([
             'packages' => $input->getArgument('packages'),
+            '--no-plugins' => $input->getOption('no-plugins'),
         ]), $output);
 
         return self::EXIT_SUCCESS;

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -82,6 +82,23 @@ For example:
 ./yii-dev install di,rbac,yii-cycle,view
 ```
 
+Problems with composer plugins
+------------------------------
+
+Sometimes some composer plugins [do not work](https://github.com/Ocramius/PackageVersions/issues/107) during virtualization.
+
+In this case use flag `--no-plugins` when installing and updating packages. For example:
+
+```bash
+./yii-dev install --no-plugins di,rbac,yii-cycle,view
+```
+
+Update example:
+
+```bash
+./yii-dev update --no-plugins injector,cache,log,proxy
+```
+
 
 SSH keys
 --------


### PR DESCRIPTION
Sometimes shit happens with plugins when the tool used on Virtualbox: Ocramius/PackageVersions#107

In such cases, flag `--no-plugins` helps out.