### PR TITLE
Fix access for apache2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ version: '3.4'
 services:
   php:
     image: yiisoftware/yii-php:7.4-apache
-    working_dir: /repo
+    working_dir: /app
     volumes:
-      - .:/repo
+      - .:/app
       # For composer usage in container; NOTE! There may be performance issues, see also https://github.com/docker/for-mac/issues/77
       - ~/.composer-docker/cache:/root/.composer/cache:delegated
+    ports:
+      - '30080:80'

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Current directory structure doesn't allow to use web server ([from docker-compose service](https://github.com/yiisoft/yii-dev-tool/blob/aeeead0a5d8d31249ea81a364f12f0850d4269b6/docker-compose.yml#L4)) without additional configuration, because apache2's DocumentRoot set to /app/public