### PR TITLE
Replace "php.exe" with "php" for windows

### DIFF
--- a/yii-dev.bat
+++ b/yii-dev.bat
@@ -13,7 +13,7 @@ rem -------------------------------------------------------------
 
 set YII_PATH=%~dp0
 
-if "%PHP_COMMAND%" == "" set PHP_COMMAND=php.exe
+if "%PHP_COMMAND%" == "" set PHP_COMMAND=php
 
 "%PHP_COMMAND%" "%YII_PATH%yii-dev" %*
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

I use `php.cmd` file in the env PATH variable. `PHP_COMMAND=php.exe` throws error in my case.
I think this fix should works fine in the `php.exe` case also