### PR TITLE
Refactor IO operations

### DIFF
--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 use Yiisoft\YiiDevTool\Infrastructure\Changelog;
@@ -182,8 +181,7 @@ final class MakeCommand extends PackageCommand
 
     private function confirm(string $message): bool
     {
-        $question = new ConfirmationQuestion($message, false);
-        return $this->getHelper('question')->ask($this->input, $this->output, $question);
+        return $this->getIO()->confirm($message, false);
     }
 
     private function choose(string $message, string $error, array $variants): string

--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -6,7 +6,6 @@ use GitWrapper\GitWorkingCopy;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ChoiceQuestion;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 use Yiisoft\YiiDevTool\Infrastructure\Changelog;
@@ -16,7 +15,6 @@ use Yiisoft\YiiDevTool\Infrastructure\Version;
 
 final class MakeCommand extends PackageCommand
 {
-    private InputInterface $input;
     private OutputInterface $output;
 
     private ?string $tag;
@@ -35,7 +33,6 @@ final class MakeCommand extends PackageCommand
 
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
-        $this->input = $input;
         $this->output = $output;
         parent::initialize($input, $output);
     }
@@ -184,18 +181,6 @@ final class MakeCommand extends PackageCommand
         return $this->getIO()->confirm($message, false);
     }
 
-    private function choose(string $message, string $error, array $variants): string
-    {
-        $helper = $this->getHelper('question');
-        $question = new ChoiceQuestion(
-            $message,
-            $variants,
-            0
-        );
-        $question->setErrorMessage($error);
-        return $helper->ask($this->input, $this->output, $question);
-    }
-
     private function getCurrentBranch(GitWorkingCopy $git): string
     {
         return trim($git->branch(['show-current' => true]));
@@ -221,7 +206,7 @@ final class MakeCommand extends PackageCommand
     private function getVersionToRelease(Version $currentVersion): Version
     {
         if ($this->tag === null) {
-            $versionType = $this->choose('What release is it?', '%s is not a valid release type.', Version::TYPES);
+            $versionType = $this->getIO()->choice('What release is it?', Version::TYPES);
             $nextVersion = $currentVersion->getNext($versionType);
         } else {
             $nextVersion = new Version($this->tag);

--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -15,8 +15,6 @@ use Yiisoft\YiiDevTool\Infrastructure\Version;
 
 final class MakeCommand extends PackageCommand
 {
-    private OutputInterface $output;
-
     private ?string $tag;
 
     private const MAIN_BRANCHES = ['master', 'main'];
@@ -31,18 +29,14 @@ final class MakeCommand extends PackageCommand
         parent::configure();
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
-    {
-        $this->output = $output;
-        parent::initialize($input, $output);
-    }
-
     protected function beforeProcessingPackages(InputInterface $input): void
     {
+        $io = $this->getIO();
+
         $this->tag = $input->getOption('tag');
 
-        if ($this->output->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
-            $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+        if ($io->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
+            $io->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
         }
     }
 

--- a/src/App/Component/Console/OutputManager.php
+++ b/src/App/Component/Console/OutputManager.php
@@ -33,6 +33,16 @@ class OutputManager
         return $this->io->isVerbose();
     }
 
+    public function getVerbosity(): int
+    {
+        return $this->io->getVerbosity();
+    }
+
+    public function setVerbosity(int $level): void
+    {
+        $this->io->setVerbosity($level);
+    }
+
     /**
      * It only prepares a package header for output, but does not output it.
      * The header will be automatically displayed later before the first message that will require output.

--- a/src/App/Component/Console/OutputManager.php
+++ b/src/App/Component/Console/OutputManager.php
@@ -133,6 +133,11 @@ class OutputManager
         return $this->delegateOutputToIO('confirm', [$question, $default], true);
     }
 
+    public function choice(string $question, array $choices, $default = null)
+    {
+        return $this->delegateOutputToIO('choice', [$question, $choices, $default], true);
+    }
+
     public function nothingHasBeenOutput(): bool
     {
         return !$this->outputDone;

--- a/src/App/Component/Console/OutputManager.php
+++ b/src/App/Component/Console/OutputManager.php
@@ -81,21 +81,21 @@ class OutputManager
 
     public function newLine($count = 1): self
     {
-        $this->delegateOutputToIO('newLine', $count);
+        $this->delegateOutputToIO('newLine', [$count]);
 
         return $this;
     }
 
     public function info($message): self
     {
-        $this->delegateOutputToIO('writeln', $message);
+        $this->delegateOutputToIO('writeln', [$message]);
 
         return $this;
     }
 
     public function warning($message): self
     {
-        $this->delegateOutputToIO('warning', $message);
+        $this->delegateOutputToIO('warning', [$message]);
 
         return $this;
     }
@@ -109,14 +109,14 @@ class OutputManager
      */
     public function error($message): self
     {
-        $this->delegateOutputToIO('error', $message, true);
+        $this->delegateOutputToIO('error', [$message], true);
 
         return $this;
     }
 
     public function success($message): self
     {
-        $this->delegateOutputToIO('success', $message);
+        $this->delegateOutputToIO('success', [$message]);
 
         return $this;
     }
@@ -142,16 +142,12 @@ class OutputManager
         }
     }
 
-    private function delegateOutputToIO(string $method, $arg = null, bool $forceOutput = false): void
+    private function delegateOutputToIO(string $method, $args = [], bool $forceOutput = false): void
     {
         if ($forceOutput || $this->io->isVerbose() || $this->nextMessageIsImportant) {
             $this->outputHeaderIfPrepared();
 
-            if ($arg === null) {
-                $this->io->$method();
-            } else {
-                $this->io->$method($arg);
-            }
+            call_user_func_array([$this->io, $method], $args);
 
             $this->outputDone = true;
             $this->nextMessageIsImportant = false;

--- a/src/App/Component/Console/OutputManager.php
+++ b/src/App/Component/Console/OutputManager.php
@@ -128,6 +128,11 @@ class OutputManager
         return $this;
     }
 
+    public function confirm(string $question, bool $default = true): bool
+    {
+        return $this->delegateOutputToIO('confirm', [$question, $default], true);
+    }
+
     public function nothingHasBeenOutput(): bool
     {
         return !$this->outputDone;
@@ -142,15 +147,33 @@ class OutputManager
         }
     }
 
-    private function delegateOutputToIO(string $method, $args = [], bool $forceOutput = false): void
+    /**
+     * Delegates a call to the specified YiiDevToolStyle method if the next message is marked important,
+     * verbose mode is configured or output is forced. Otherwise, it does nothing and just returns null.
+     *
+     * If some data was previously prepared for output and output is needed,
+     * it outputs the prepared data before YiiDevToolStyle method call.
+     *
+     * @param string $method YiiDevToolStyle method name
+     * @param array $args call arguments
+     * @param bool $forceOutput whether to force call
+     * @return mixed method call result or null
+     *
+     * @see YiiDevToolStyle
+     */
+    private function delegateOutputToIO(string $method, $args = [], bool $forceOutput = false)
     {
+        $result = null;
+
         if ($forceOutput || $this->io->isVerbose() || $this->nextMessageIsImportant) {
             $this->outputHeaderIfPrepared();
 
-            call_user_func_array([$this->io, $method], $args);
+            $result = call_user_func_array([$this->io, $method], $args);
 
             $this->outputDone = true;
             $this->nextMessageIsImportant = false;
         }
+
+        return $result;
     }
 }


### PR DESCRIPTION
OutputManager acts as a facade in front of all I/O operations. It makes decisions about allowing or suppressing certain messages in a specific environment. 

It is important to do all I/O operations through it. This is how the internal architecture of the tool was originally conceived.