### PR TITLE
Mention SSH key

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ See [example](packages.local.php.example).
 
 ### Step 4: install packages
 
+In order to work with Github via SSH, you have to [add](https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account) your public SSH key to Github account. Add key if you have not done it before.
+
 Now install the packages:
 
 ```bash


### PR DESCRIPTION
Instructions in README does not work for those who have never set up SSH key with Github account.

It should be stated that SSH key is required.

| Q             | A
| ------------- | ---
| Is bugfix?    | No
| New feature?  | No
| Breaks BC?    | No
| Fixed issues  | -
