### PR TITLE
Rename command `list-packages` to `list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ git/push                  | Push changes into package repositories.
 git/status                | Show git status of packages.
 git/pr/create             | Create a pull request at GitHub.
 github/settings           | Change settings of a GitHub repository.
-list-packages             | List enabled packages.
+list                      | List enabled packages.
 install                   | Install packages.
 update                    | Update packages.
 lint                      | Check packages according to PSR-12 standard.

--- a/src/App/Command/ListCommand.php
+++ b/src/App/Command/ListCommand.php
@@ -7,14 +7,12 @@ namespace Yiisoft\YiiDevTool\App\Command;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
-final class ListPackagesCommand extends PackageCommand
+final class ListCommand extends PackageCommand
 {
-    private string $command;
-
     protected function configure()
     {
         $this
-            ->setName('list-packages')
+            ->setName('list')
             ->setDescription('List all packages');
 
         parent::configure();

--- a/src/App/YiiDevToolApplication.php
+++ b/src/App/YiiDevToolApplication.php
@@ -7,7 +7,7 @@ namespace Yiisoft\YiiDevTool\App;
 use RuntimeException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\HelpCommand;
-use Symfony\Component\Console\Command\ListCommand;
+use Symfony\Component\Console\Command\ListCommand as ListCommandsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -23,7 +23,7 @@ use Yiisoft\YiiDevTool\App\Command\Github\ProtectBranchCommand;
 use Yiisoft\YiiDevTool\App\Command\Github\SettingsCommand;
 use Yiisoft\YiiDevTool\App\Command\InstallCommand;
 use Yiisoft\YiiDevTool\App\Command\LintCommand;
-use Yiisoft\YiiDevTool\App\Command\ListPackagesCommand;
+use Yiisoft\YiiDevTool\App\Command\ListCommand;
 use Yiisoft\YiiDevTool\App\Command\Release\MakeCommand;
 use Yiisoft\YiiDevTool\App\Command\Release\WhatCommand;
 use Yiisoft\YiiDevTool\App\Command\Replicate\ReplicateComposerConfigCommand;
@@ -49,6 +49,7 @@ class YiiDevToolApplication extends Application
     public function __construct()
     {
         parent::__construct($this->header);
+        $this->setDefaultCommand('list-commands');
     }
 
     public function setRootDir(string $path): self
@@ -71,14 +72,14 @@ class YiiDevToolApplication extends Application
     {
         return [
             (new HelpCommand())->setHidden(true),
-            (new ListCommand())->setHidden(true),
+            (new ListCommandsCommand())->setName('list-commands')->setHidden(true),
             new CheckoutCommand(),
             new CommitCommand(),
             new TestCommand(),
             new RequestPullCommand(),
             new ExecCommand(),
             new ComposerFixDependenciesCommand(),
-            new ListPackagesCommand(),
+            new ListCommand(),
             new InstallCommand(),
             new LintCommand(),
             new PullCommand(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #175 

Old command `list` for list commands renamed to `list-commands`.
