### PR TITLE
Fixed: instead of `composer update` on command `composer/update` was runned `composer install`

### DIFF
--- a/src/App/PackageService.php
+++ b/src/App/PackageService.php
@@ -36,7 +36,7 @@ final class PackageService
         OutputManager $io
     ): void {
         $this->composerInstallOrUpdate(
-            'install',
+            'update',
             $package,
             $additionalOptions,
             $errorList,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
