### PR TITLE
Improve output for release/what command

### DIFF
--- a/src/App/Command/Release/WhatCommand.php
+++ b/src/App/Command/Release/WhatCommand.php
@@ -123,7 +123,7 @@ final class WhatCommand extends Command
 
         uasort(
             $packagesWithoutRelease,
-            static fn($a, $b) => [$a['dependencies'], -$a['dependents']] <=> [$b['dependencies'], -$b['dependents']]
+            static fn ($a, $b) => [$a['dependencies'], -$a['dependents']] <=> [$b['dependencies'], -$b['dependents']]
         );
 
         $successStyle = new TableCellStyle(['fg' => 'green']);
@@ -174,7 +174,8 @@ final class WhatCommand extends Command
 
         $tableIO->render();
 
-        $io->important()->info(<<<TEXT
+        $io->important()->info(
+            <<<TEXT
         <success>Out deps</success> – count unreleased packages from which the package depends
         <success>In deps</success> – count unreleased packages which depends on the package
         TEXT
@@ -239,6 +240,6 @@ final class WhatCommand extends Command
 
     private function concatDependencies($deps): string
     {
-        return implode("\n", array_map(fn(array $array) => implode(', ', $array), array_chunk($deps, 7)));
+        return implode("\n", array_map(fn (array $array) => implode(', ', $array), array_chunk($deps, 7)));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 
 
Improved output for release/what command. Now the output looks like on the image:

<img width="988" alt="image" src="https://user-images.githubusercontent.com/6815714/164104923-27c9606c-c341-41fc-ae29-5521232e90e4.png">

`In/out deps` named specially to save a space