### PR TITLE
Use vendor name everywhere and remove setting to upstream repository.

### DIFF
--- a/src/App/Command/Composer/UpdateCommand.php
+++ b/src/App/Command/Composer/UpdateCommand.php
@@ -70,8 +70,6 @@ final class UpdateCommand extends PackageCommand
             return;
         }
 
-        $this->packageService->gitSetUpstream($package, $io);
-
         $this->packageService->removeSymbolicLinks($package, $this->getPackageList(), $io);
 
         if ($this->doesPackageContainErrors($package)) {

--- a/src/App/Command/Git/CloneCommand.php
+++ b/src/App/Command/Git/CloneCommand.php
@@ -39,8 +39,6 @@ final class CloneCommand extends PackageCommand
             return;
         }
 
-        $this->packageService->gitSetUpstream($package, $io);
-
         if (!$io->isVerbose()) {
             $io
                 ->important()

--- a/src/App/Command/Git/PullCommand.php
+++ b/src/App/Command/Git/PullCommand.php
@@ -30,13 +30,7 @@ final class PullCommand extends PackageCommand
         $io = $this->getIO();
         $io->preparePackageHeader($package, 'Pulling package {package}');
 
-        if ($package->isConfiguredRepositoryPersonal()) {
-            $gitCommand = ['git', 'pull', 'upstream', 'master'];
-        } else {
-            $gitCommand = ['git', 'pull'];
-        }
-
-        $process = new Process($gitCommand, $package->getPath());
+        $process = new Process(['git', 'pull'], $package->getPath());
         $process
             ->setTimeout(null)
             ->run();

--- a/src/App/Command/InstallCommand.php
+++ b/src/App/Command/InstallCommand.php
@@ -64,8 +64,6 @@ final class InstallCommand extends PackageCommand
             }
         }
 
-        $this->packageService->gitSetUpstream($package, $io);
-
         $this->packageService->removeSymbolicLinks($package, $this->getPackageList(), $io);
 
         if ($this->doesPackageContainErrors($package)) {

--- a/src/App/Command/Release/WhatCommand.php
+++ b/src/App/Command/Release/WhatCommand.php
@@ -252,7 +252,7 @@ final class WhatCommand extends Command
 
     private function removeVendorName(string $packageName): string|array
     {
-        return str_replace('yiisoft/', '', $packageName);
+        return preg_replace('/^[a-z0-9][a-z0-9-]*[a-z0-9]\//i', '', $packageName);
     }
 
     private function concatDependencies($deps): string

--- a/src/App/Command/UpdateCommand.php
+++ b/src/App/Command/UpdateCommand.php
@@ -72,8 +72,6 @@ final class UpdateCommand extends PackageCommand
             return;
         }
 
-        $this->packageService->gitSetUpstream($package, $io);
-
         $this->packageService->removeSymbolicLinks($package, $this->getPackageList(), $io);
 
         if ($this->doesPackageContainErrors($package)) {
@@ -102,13 +100,7 @@ final class UpdateCommand extends PackageCommand
             ->important()
             ->info('Pulling repository');
 
-        if ($package->isConfiguredRepositoryPersonal()) {
-            $gitCommand = ['git', 'pull', 'upstream', 'master'];
-        } else {
-            $gitCommand = ['git', 'pull'];
-        }
-
-        $process = new Process($gitCommand);
+        $process = new Process(['git', 'pull']);
         $process->setWorkingDirectory($package->getPath());
 
         $process

--- a/src/App/Component/Console/PackageCommand.php
+++ b/src/App/Component/Console/PackageCommand.php
@@ -237,22 +237,6 @@ class PackageCommand extends Command
             return false;
         }
 
-        // TODO: Implement extensible validation instead of checking command names
-        if ($this->getName() === 'pull') {
-            if ($package->isConfiguredRepositoryPersonal()) {
-                if (!$gitWorkingCopy->hasRemote('upstream')) {
-                    $io->error([
-                        "Package <package>{$package->getId()}</package> repository is personal and has no remote 'upstream'.",
-                        'To fix, run the command:',
-                        '',
-                        "  <cmd>{$this->getExampleCommandPrefix()}yii-dev install {$package->getId()}</cmd>",
-                    ]);
-
-                    return false;
-                }
-            }
-        }
-
         return true;
     }
 

--- a/src/App/Component/Package/Package.php
+++ b/src/App/Component/Package/Package.php
@@ -50,8 +50,12 @@ class Package
         } elseif ($config === 'https') {
             $this->configuredRepositoryUrl = "https://github.com/$this->owner/$id.git";
         } elseif (preg_match('|^[a-z0-9-]+/[a-z0-9_.-]+$|i', $config)) {
+            preg_match('|^([a-z0-9-]+)/[a-z0-9_.-]+$|i', $config, $ownerMatches);
+            $this->owner = $ownerMatches[1] ?? $owner;
             $this->configuredRepositoryUrl = "git@github.com:$config.git";
         } else {
+            preg_match('|^git@github.com:([a-z0-9-]+)/[a-z0-9_.-]+$|i', $config, $ownerMatches);
+            $this->owner = $ownerMatches[1] ?? $owner;
             $this->configuredRepositoryUrl = $config;
         }
 
@@ -80,28 +84,6 @@ class Package
         }
 
         return $this->configuredRepositoryUrl;
-    }
-
-    public function getOriginalRepositoryHttpsUrl(): string
-    {
-        return "https://github.com/{$this->owner}/{$this->id}.git";
-    }
-
-    public function getPossibleOriginalRepositoryUrls(): array
-    {
-        return [
-            "https://github.com/{$this->owner}/{$this->id}.git",
-            "git@github.com:{$this->owner}/{$this->id}.git",
-        ];
-    }
-
-    public function isConfiguredRepositoryPersonal(): bool
-    {
-        return !in_array(
-            $this->getConfiguredRepositoryUrl(),
-            $this->getPossibleOriginalRepositoryUrls(),
-            true
-        );
     }
 
     public function disabled(): bool

--- a/src/App/PackageService.php
+++ b/src/App/PackageService.php
@@ -89,21 +89,6 @@ final class PackageService
         $errorList->set($package, $output, 'cloning package repository');
     }
 
-    public function gitSetUpstream(Package $package, OutputManager $io): void
-    {
-        if ($package->isConfiguredRepositoryPersonal()) {
-            $gitWorkingCopy = $package->getGitWorkingCopy();
-            $remoteName = 'upstream';
-
-            if (!$gitWorkingCopy->hasRemote($remoteName)) {
-                $upstreamUrl = $package->getOriginalRepositoryHttpsUrl();
-                $io->info("Setting repository remote 'upstream' to <file>$upstreamUrl</file>");
-                $gitWorkingCopy->addRemote($remoteName, $upstreamUrl);
-                $io->done();
-            }
-        }
-    }
-
     public function createSymbolicLinks(PackageList $packageList, OutputManager $io): void
     {
         $io


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️

If the last 3 pull requests pass, there will be no need to set up an upstream repository